### PR TITLE
Add support for setting `pathlen` on CA certificates and intermediate CA

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -93,6 +93,15 @@ func NewInitCommand() cli.Command {
 				Name:  "permit-domain",
 				Usage: "Create a CA restricted to subdomains of this domain (can be specified multiple times)",
 			},
+			cli.IntFlag{
+				Name:  "path-length",
+				Value: 0,
+				Usage: "Maximum number of non-self-issued intermediate certificates that may follow this CA certificate in a valid certification path",
+			},
+			cli.BoolFlag{
+				Name:  "exclude-path-length",
+				Usage: "Exclude 'Path Length Constraint' from this CA certificate allowing this CA to issue intermediate certificates",
+			},
 		},
 		Action: initAction,
 	}
@@ -108,6 +117,11 @@ func initAction(c *cli.Context) {
 
 	if depot.CheckCertificate(d, formattedName) || depot.CheckPrivateKey(d, formattedName) {
 		fmt.Fprintf(os.Stderr, "CA with specified name \"%s\" already exists!\n", formattedName)
+		os.Exit(1)
+	}
+
+	if c.IsSet("path-length") && c.IsSet("exclude-path-length") {
+		fmt.Fprintf(os.Stderr, "The \"path-length\" and \"exclude-path-length\" flags cannot be used together!\n")
 		os.Exit(1)
 	}
 
@@ -176,7 +190,7 @@ func initAction(c *cli.Context) {
 		}
 	}
 
-	crt, err := pkix.CreateCertificateAuthority(key, c.String("organizational-unit"), expiresTime, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), c.String("common-name"), c.StringSlice("permit-domain"))
+	crt, err := pkix.CreateCertificateAuthority(key, c.String("organizational-unit"), expiresTime, c.String("organization"), c.String("country"), c.String("province"), c.String("locality"), c.String("common-name"), c.StringSlice("permit-domain"), c.Int("path-length"), c.Bool("exclude-path-length"))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Create certificate error:", err)
 		os.Exit(1)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -100,7 +100,7 @@ func NewInitCommand() cli.Command {
 			},
 			cli.BoolFlag{
 				Name:  "exclude-path-length",
-				Usage: "Exclude 'Path Length Constraint' from this CA certificate allowing this CA to issue intermediate certificates",
+				Usage: "Exclude 'Path Length Constraint' from this CA certificate",
 			},
 		},
 		Action: initAction,

--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -75,7 +75,7 @@ func setupCA(t *testing.T, dt depot.Depot) {
 	}
 
 	// create certificate authority
-	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName, nil)
+	caCert, err := pkix.CreateCertificateAuthority(key, caName, time.Now().Add(1*time.Minute), "", "", "", "", caName, nil, 0, false)
 	if err != nil {
 		t.Fatalf("could not create authority cert: %v", err)
 	}

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -67,6 +67,11 @@ func NewSignCommand() cli.Command {
 				Name:  "intermediate",
 				Usage: "Whether generated certificate should be a intermediate",
 			},
+			cli.IntFlag{
+				Name:  "path-length",
+				Value: 0,
+				Usage: "Maximum number of non-self-issued intermediate certificates that may follow this CA certificate in a valid certification path",
+			},
 		},
 		Action: newSignAction,
 	}
@@ -140,8 +145,13 @@ func newSignAction(c *cli.Context) {
 	var crtOut *pkix.Certificate
 	if c.Bool("intermediate") {
 		fmt.Fprintln(os.Stderr, "Building intermediate")
-		crtOut, err = pkix.CreateIntermediateCertificateAuthority(crt, key, csr, expiresTime)
+		crtOut, err = pkix.CreateIntermediateCertificateAuthority(crt, key, csr, expiresTime, c.Int("path-length"))
 	} else {
+		if c.IsSet("path-length") {
+			fmt.Fprintln(os.Stderr, "The 'path-length' can only be used with 'intermediate' flag.")
+			os.Exit(1)
+		}
+
 		crtOut, err = pkix.CreateCertificateHost(crt, key, csr, expiresTime)
 	}
 

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -26,7 +26,7 @@ import (
 
 // CreateCertificateAuthority creates Certificate Authority using existing key.
 // CertificateAuthorityInfo returned is the extra infomation required by Certificate Authority.
-func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string, permitDomains []string) (*Certificate, error) {
+func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time.Time, organization string, country string, province string, locality string, commonName string, permitDomains []string, pathlen int, excludePathlen bool) (*Certificate, error) {
 	authTemplate := newAuthTemplate()
 
 	subjectKeyID, err := GenerateSubjectKeyID(key.Public)
@@ -57,6 +57,15 @@ func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time
 	if len(permitDomains) > 0 {
 		authTemplate.PermittedDNSDomainsCritical = true
 		authTemplate.PermittedDNSDomains = permitDomains
+	}
+
+	if !excludePathlen {
+		if pathlen > 0 {
+			authTemplate.MaxPathLen = pathlen
+			authTemplate.MaxPathLenZero = false
+		}
+	} else {
+		authTemplate.MaxPathLenZero = false
 	}
 
 	crtBytes, err := x509.CreateCertificate(rand.Reader, &authTemplate, &authTemplate, key.Public, key.Private)

--- a/pkix/cert_auth.go
+++ b/pkix/cert_auth.go
@@ -78,7 +78,7 @@ func CreateCertificateAuthority(key *Key, organizationalUnit string, expiry time
 
 // CreateIntermediateCertificateAuthority creates an intermediate
 // CA certificate signed by the given authority.
-func CreateIntermediateCertificateAuthority(crtAuth *Certificate, keyAuth *Key, csr *CertificateSigningRequest, proposedExpiry time.Time) (*Certificate, error) {
+func CreateIntermediateCertificateAuthority(crtAuth *Certificate, keyAuth *Key, csr *CertificateSigningRequest, proposedExpiry time.Time, pathlen int) (*Certificate, error) {
 	authTemplate := newAuthTemplate()
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
@@ -87,7 +87,11 @@ func CreateIntermediateCertificateAuthority(crtAuth *Certificate, keyAuth *Key, 
 		return nil, err
 	}
 	authTemplate.SerialNumber.Set(serialNumber)
-	authTemplate.MaxPathLenZero = false
+
+	if pathlen > 0 {
+		authTemplate.MaxPathLen = pathlen
+		authTemplate.MaxPathLenZero = false
+	}
 
 	rawCsr, err := csr.GetRawCertificateSigningRequest()
 	if err != nil {

--- a/pkix/cert_auth_test.go
+++ b/pkix/cert_auth_test.go
@@ -28,7 +28,7 @@ func TestCreateCertificateAuthority(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", []string{".example.com"})
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", []string{".example.com"}, 0, false)
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}

--- a/pkix/crl_test.go
+++ b/pkix/crl_test.go
@@ -49,7 +49,7 @@ func TestCreateCertificateRevocationList(t *testing.T) {
 		t.Fatal("Failed creating rsa key:", err)
 	}
 
-	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", nil)
+	crt, err := CreateCertificateAuthority(key, "OU", time.Now().AddDate(5, 0, 0), "test", "US", "California", "San Francisco", "CA Name", nil, 0, false)
 	if err != nil {
 		t.Fatal("Failed creating certificate authority:", err)
 	}


### PR DESCRIPTION
Taken from [RFC 5280](https://www.rfc-editor.org/rfc/rfc5280#page-39), section 4.2.1.9:

> A `pathLenConstraint` of zero indicates that no non-self-issued intermediate CA certificates may follow in a valid certification path. Where it appears, the pathLenConstraint field MUST be greater than or equal to zero. Where `pathLenConstraint` does not appear, no limit is imposed.

I.e. a `pathLenConstraintof` 0 does still allow the CA to issue certificates, but these certificates must be end-entity-certificates (the CA flag in `BasicConstraints` is `false` - these are the "normal" certificates that are issued to people or organizations).

It also implies that with this certificate, the CA must not issue intermediate CA certificates (where the CA flag is true again - these are certificates that could potentially issue further certificates, thereby increasing the `pathLen` by 1).

An absent `pathLenConstraint` on the other hand means that there is no limitation considering the length of certificate paths built from an end-entity certificate that would lead up to our example CA certificate. This implies that the CA could issue an intermediate certificate for a sub CA, this sub CA could again issue an intermediate certificate, this sub CA could again... until finally one sub CA would issue an end-entity certificate.

If the `pathLenConstraintof` a given CA certificate is > 0, then it expresses the number of possible intermediate CA certificates in a path built from an end-entity certificate up to the CA certificate. Let's say CA X has a `pathLenConstraint` of 2, the end-entity certificate is issued to EE. Then the following scenarios are valid (I denoting an intermediate CA certificate)

### Example

**Create CA key**
```
$ certstrap init --common-name CA --exclude-path-length
[...]
$ openssl x509 -noout -text -in out/CA.crt
[...]
        X509v3 extensions:
            X509v3 Key Usage: critical
                Certificate Sign, CRL Sign
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Subject Key Identifier:
                AE:1B:C3:B5:2C:29:05:3B:D2:94:D7:09:27:15:28:5A:04:D7:78:C7
[...]
```

**Create intermediate CA 1 key**
```
$ certstrap request-cert --common-name ICA1
[...]
$ certstrap sign ICA1 --CA CA --intermediate --path-length 1
[...]
$ openssl x509 -noout -text -in out/ICA1.crt
[...]
        X509v3 extensions:
            X509v3 Key Usage: critical
                Certificate Sign, CRL Sign
            X509v3 Basic Constraints: critical
                CA:TRUE, pathlen:1
            X509v3 Subject Key Identifier:
                1D:86:5B:08:0B:81:4A:12:02:0E:F0:B0:32:A1:F8:6D:88:F5:3A:4E
            X509v3 Authority Key Identifier:
                keyid:AE:1B:C3:B5:2C:29:05:3B:D2:94:D7:09:27:15:28:5A:04:D7:78:C7
[...]
```

**Create intermediate CA 2 key**
```
$ certstrap request-cert --common-name ICA2
[...]
$ certstrap sign ICA2 --CA ICA1 --intermediate
[...]
$ openssl x509 -noout -text -in out/ICA12crt
[...]
        X509v3 extensions:
            X509v3 Key Usage: critical
                Certificate Sign, CRL Sign
            X509v3 Basic Constraints: critical
                CA:TRUE, pathlen:0
            X509v3 Subject Key Identifier:
                47:0C:F5:1B:A8:72:64:D1:56:4B:D6:FB:AC:40:68:39:58:77:38:AA
            X509v3 Authority Key Identifier:
                keyid:1D:86:5B:08:0B:81:4A:12:02:0E:F0:B0:32:A1:F8:6D:88:F5:3A:4E
[...]
```